### PR TITLE
updated the dates for APAC conferences left in 2022 and added an addi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,53 +6,53 @@ Below is a list of infosec / hacking conferences in Asia Pacific organised by mo
 [![Twitter](https://img.shields.io/badge/twitter-@hellodanielting-blue.svg)](https://twitter.com/hellodanielting)
 
 # Conferences by Month
-| Month    | Location                           | Conference | Approx. Attendees* |
-|----------|------------------------------------|-------------|-------------|
-| February | Melbourne, Victoria, Australia     | [Kids Securiday](https://www.securiday.com/) | ~100-250 |
-| February | Perth, WA, Australia               | [WAHCKon](https://wahckon.org.au/) | ~350 |
-| March    | Brisbane, Queensland, Australia    | [CrikeyCon](https://www.crikeycon.com/) | ~800 |
-| March    | Melbourne, Victoria, Australia     | [BSides Melbourne](https://www.bsidesmelbourne.com/) | 400-450 |
-| March    | Goa, India                         | [Nullcon](https://nullcon.net) | Unknown |
-| March    | Brisbane, Australia                | [BrisSEC](https://www.aisa.org.au/Public/Events/Conferences/BrisSEC_2018/BrisSEC18.aspx) | Unknown |
-| March    | Tokyo, Japan                       | [TechNet Tokyo](https://afceatokyo.org/technet/) | 600-1000 |
-| April    | Adelaide, South Australia, Australia | [SecTalks Halfday](https://sessionize.com/sectalks-halfday/) | Unknown - New Conference |
-| May      | Sydney, NSW, Australia             | [Kids Securiday](https://www.securiday.com/) | ~100-250 |
-| May      | Canberra, ACT, Australia           | [BSides Canberra](http://www.bsidesau.com.au/) | 1950 + volunteers and speakers |
-| May      | Sunshine Coast, Queensland, Australia | [TuskCon](http://tuskcon.org/) | 50-60 |
-| May      | Singapore, Singapore               | [Infosec in the City](https://www.infosec-city.com/) | Unknown |
-| May      | Hong Kong, China                   | [REVULN](https://revuln.com) | Unknown |
-| May      | Singapore, Singapore               | [Blackhat Asia](https://www.blackhat.com/) | Unknown |
-| June     | Melbourne, Victoria, Australia     | [0xCC](https://www.0xcc.sh/) | 200 |
-| June     | Melbourne, Australia               | [OzSecCon](https://ozseccon.com/) | ~250 |
-| June     | Gold Coast, Queensland, Australia  | [AusCERT](https://www.auscert.org.au/events/2018-05-29-auscert2018-17th-annual-auscert-cyber-security-conference) | 700 |
-| June     | Brisbane, Australia                | [BSides Brisbane](https://bsidesbrisbane.com/) | ~450 (New Conference) |
-| July     | Sydney, NSW, Australia             | [MRE2020](https://federation.edu.au/icsl/mre2020) | ~300 |
-| August   | Canberra, ACT, Australia           | [Kids Securiday](https://www.securiday.com/) | ~100-250 |
-| August   | Singapore, Singapore               | [HITB GSEC](https://gsec.hitb.org/) | Unknown |
-| September| Sydney, NSW, Australia             | [BSides Sydney](http://bsidessydney.org/) | Unknown |
-| September| Perth, WA, Australia               | [BSides Perth](https://bsidesperth.com.au/) | ~280 |
-| September| Kochi, Kerala, India               | [c0c0n 12](https://www.c0c0n.org/) | ~2000 |
-| September| Tagaytay, Cavite, Philippines      | [ROOTCON](https://www.rootcon.org/) | ~700-1000 |
-| October  | Tokyo, Japan                       | [BSides Tokyo](https://bsides.tokyo/en/) | Unknown |
-| October  | Melbourne, Victoria, Australia     | [CyberConference - AISA](https://cyberconference.com.au/) | Unknown |
-| October  | Christchurch, New Zealand          | [CHCon](https://2019.chcon.nz/) | Unknown |
-| October  | Indore, India                      | [Hakon India](http://www.hakonindia.org/) | Unknown |
-| October  | Perth, WA, Australia               | [ISACA SecureIT Conference](https://engage.isaca.org/perthchapter/events/recentcommunityeventsdashboard) |
-| October  | Delhi, India                       | [Bsides Delhi](https://bsidesdelhi.in/) | ~350-400 |
-| October  | Kuala Lumpur, Malaysia             | [Nanosec Asia](https://www.nanosec.asia/) | ~200 |
-| November | Wellington, New Zealand            | [Kawaiicon](https://kawaiicon.org/) | ~1000 |
-| November | Virtual, Australia                 | [ComfyCon Au](https://www.comfyconau.rocks/) | 300 |
-| November | Melbourne, Victoria, Australia     | [OWASP AppSec Day](https://appsecday.io/) | ~1000 |
-| November | Melbourne, Victoria, Australia     | [Security Influence & Trust Summit](https://sitempowers.com/) | ~100 |
-| November | Wellington, New Zealand            | [purplecon](https://purplecon.nz/#) | Unknown - new conference | 
-| November | Melbourne, Australia               | [IoT Authentication](http://www.authiot2018.conferences.academy/) | Unknown |
-| November | Virtual, Australia                 | [ComfyCon Au (Summer Edition)](https://www.comfyconau.rocks/) | 300 |
-| November | Ahmedabad, India                   | [Bsides Ahmedabad](https://www.bsidesahmedabad.in/) | Unknown |
-| November | Kathmandu, Nepal                   | [Threat Con](https://threatcon.io/) | Unknown |
-| December | Perth, Western Australia, Australia| [WACTF](https://capture.tf/) | ~230 |
-| December | Brisbane, Australia                | [Asiacrypt](https://asiacrypt.iacr.org/2018/) | Unknown |
-| December | Adelaide, South Australia, Australia | [Kangacrypt](https://kangacrypt.info) | Unknown - new conference |
-| December | Melbourne, Victoria, Australia     | [COSAC](https://cosac.net/) | Unknown |
+| Month    | Location               | Conference | Approx. Attendees* | Next Event |
+|----------|------------------------|------------|--------------------|------------|
+| February | Melbourne, VIC, AU     | [Kids Securiday](https://www.securiday.com/) | ~100-250 | |
+| February | Perth, WA, AU          | [WAHCKon](https://wahckon.org.au/) | ~350 | |
+| March    | Melbourne, VIC, AU     | [BSides Melbourne](https://www.bsidesmelbourne.com/) | 400-450 |
+| March    | Goa, India             | [Nullcon](https://nullcon.net) | Unknown |
+| March    | Brisbane, AU           | [BrisSEC](https://www.aisa.org.au/Public/Events/Conferences/BrisSEC_2018/BrisSEC18.aspx) | Unknown |
+| March    | Tokyo, Japan           | [TechNet Tokyo](https://afceatokyo.org/technet/) | 600-1000 |
+| April    | Adelaide, SA, AU       | [SecTalks Halfday](https://sessionize.com/sectalks-halfday/) | Unknown - New Conference |
+| May      | Sydney, NSW, AU        | [Kids Securiday](https://www.securiday.com/) | ~100-250 |
+| May      | Canberra, ACT, AU      | [BSides Canberra](http://www.bsidesau.com.au/) | 1950 + volunteers and speakers |
+| May      | Sunshine Coast, QLD, AU | [TuskCon](http://tuskcon.org/) | 50-60 |
+| May      | Singapore, Singapore   | [Infosec in the City](https://www.infosec-city.com/) | Unknown |
+| May      | Hong Kong, China       | [REVULN](https://revuln.com) | Unknown |
+| May      | Singapore, Singapore   | [Blackhat Asia](https://www.blackhat.com/) | Unknown |
+| June     | Melbourne, VIC, AU     | [0xCC](https://www.0xcc.sh/) | 200 |
+| June     | Melbourne, AU          | [OzSecCon](https://ozseccon.com/) | ~250 |
+| June     | Gold Coast, QLD, AU    | [AusCERT](https://www.auscert.org.au/events/2018-05-29-auscert2018-17th-annual-auscert-cyber-security-conference) | 700 |
+| June     | Brisbane, AU           | [BSides Brisbane](https://bsidesbrisbane.com/) | ~450 (New Conference) |
+| July     | Sydney, NSW, AU        | [MRE2020](https://federation.edu.au/icsl/mre2020) | ~300 |
+| August   | Canberra, ACT, AU      | [Kids Securiday](https://www.securiday.com/) | ~100-250 |
+| August   | Singapore, Singapore   | [HITB GSEC](https://gsec.hitb.org/) | Unknown |
+| September| Brisbane, QLD, AU      | [CrikeyCon](https://www.crikeycon.com/) | ~800 | September 3, 2022 |
+| September| Sydney, NSW, AU        | [BSides Sydney](http://bsidessydney.org/) | Unknown |
+| September| Perth, WA, AU          | [BSides Perth](https://bsidesperth.com.au/) | ~280 |
+| September| Kochi, Kerala, India   | [c0c0n 12](https://www.c0c0n.org/) | ~2000 | September 21-24, 2022 |
+| September| Tagaytay, Cavite, Philippines      | [ROOTCON](https://www.rootcon.org/) | ~700-1000 | September 28-30, 2022 |
+| October  | Tokyo, Japan           | [BSides Tokyo](https://bsides.tokyo/en/) | Unknown |
+| October  | Melbourne, VIC, AU     | [CyberConference - AISA](https://cyberconference.com.au/) | Unknown | October 11-13, 2022 |
+| October  | Christchurch, NZ       | [CHCon](https://2019.chcon.nz/) | Unknown |
+| October  | Indore, India          | [Hakon India](http://www.hakonindia.org/) | Unknown |
+| October  | Perth, WA, AU          | [ISACA SecureIT Conference](https://engage.isaca.org/perthchapter/events/recentcommunityeventsdashboard) |
+| October  | Gold Coast, QLD, AU    | [BSides Gold Coast](http://www.bsidesgoldcoast.com/) | Unknown - New Conference | October 22, 2022 |
+| October  | Delhi, India           | [Bsides Delhi](https://bsidesdelhi.in/) | ~350-400 |
+| October  | Kuala Lumpur, Malaysia | [Nanosec Asia](https://www.nanosec.asia/) | ~200 |
+| November | Wellington, NZ         | [Kawaiicon](https://kawaiicon.org/) | ~1000 |
+| November | Virtual, AU            | [ComfyCon Au](https://www.comfyconau.rocks/) | 300 |
+| November | Melbourne, VIC, AU     | [OWASP AppSec Day](https://appsecday.io/) | ~1000 |
+| November | Melbourne, VIC, AU     | [Security Influence & Trust Summit](https://sitempowers.com/) | ~100 |
+| November | Wellington, NZ         | [purplecon](https://purplecon.nz/#) | Unknown - new conference | 
+| November | Melbourne, AU          | [IoT Authentication](http://www.authiot2018.conferences.academy/) | Unknown |
+| November | Virtual, AU            | [ComfyCon Au (Summer Edition)](https://www.comfyconau.rocks/) | 300 |
+| November | Ahmedabad, India       | [Bsides Ahmedabad](https://www.bsidesahmedabad.in/) | Unknown | October 1, 2022 |
+| November | Kathmandu, Nepal       | [Threat Con](https://threatcon.io/) | Unknown |
+| December | Perth, Western Australia, AU | [WACTF](https://capture.tf/) | ~230 |
+| December | Taipei, Taiwan         | [Asiacrypt](https://asiacrypt.iacr.org/2022/) | Unknown | December 5-9, 2022 |
+| December | Adelaide, South AU, AU | [Kangacrypt](https://kangacrypt.info) | Unknown - new conference |
 
 
 * Approximate number of attendees is forecasted based on available tickets for a year, or the number of tickets sold in the previous year the event ran. Numbers may not be entirely accurate as there can be large fluctuations year on year.


### PR DESCRIPTION
…tional column

There were really 3 small changes to this repo:  first, i added a new column for the next conferences in APAC in 2022.  Second, I shortened any Australia country designation to AU and New Zealand to NZ to make room for the new column.  Finally, I updated several of the dates for Australian conferences.

Signed-off-by: Paul McCarty <mcsnet@yahoo.com>